### PR TITLE
Refactor modinstaller class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -157,7 +157,6 @@
     "-p",
     "*test*.py"
   ],
-"pythonTestExplorer.testplanEnabled": false,
 "python.analysis.inlayHints.callArgumentNames": "off",
 "python.analysis.inlayHints.functionReturnTypes": true,
 "python.analysis.inlayHints.variableTypes": true,

--- a/pykotor/extract/capsule.py
+++ b/pykotor/extract/capsule.py
@@ -167,6 +167,7 @@ class Capsule:
         restype: ResourceType,
         resdata: bytes,
     ):
+        container: RIM | ERF
         if is_rim_file(self._path.name):
             container = read_rim(self._path)
             container.set_data(resname, restype, resdata)

--- a/pykotor/extract/installation.py
+++ b/pykotor/extract/installation.py
@@ -115,25 +115,25 @@ class Installation:
         self._streamwaves: list[FileResource] = []
         self._rims: dict[str, list[FileResource]] = {}
 
+        self.log.add_note("Load chitin...")
+        self.load_chitin()
+        self.log.add_note("Load lips...")
+        self.load_lips()
         self.log.add_note("Load modules...")
         self.load_modules()
         self.log.add_note("Load override...")
         self.load_override()
-        self.log.add_note("Load lips...")
-        self.load_lips()
-        self.log.add_note("Load textures...")
-        self.load_textures()
-        self.log.add_note("Load chitin...")
-        self.load_chitin()
+        self.log.add_note("Load rims...")
+        self.load_rims()
         self.log.add_note("Load streammusic...")
         self.load_streammusic()
         self.log.add_note("Load streamsounds...")
         self.load_streamsounds()
         self.log.add_note(f"Load {'streamvoice' if self.game() == Game.K2 else 'streamwaves'}...")
         self.load_streamwaves()
-        self.log.add_note("Load rims...")
-        self.load_rims()
-        self.log.add_note("Finished loading installation")
+        self.log.add_note("Load textures...")
+        self.load_textures()
+        self.log.add_note("Finished loading the installation")
 
     # region Get Paths
     def path(self) -> CaseAwarePath:

--- a/pykotor/extract/installation.py
+++ b/pykotor/extract/installation.py
@@ -574,8 +574,8 @@ class Installation:
             self.log.add_error(
                 f"Could not find '{resname}.{restype}' during resource lookup.",
             )
-
-        return None
+            return None
+        return search
 
     def resources(
         self,

--- a/pykotor/extract/installation.py
+++ b/pykotor/extract/installation.py
@@ -114,6 +114,7 @@ class Installation:
         self._streamsounds: list[FileResource] = []
         self._streamwaves: list[FileResource] = []
         self._rims: dict[str, list[FileResource]] = {}
+        self._game: Game | None = None
 
         self.log.add_note("Load chitin...")
         self.load_chitin()
@@ -504,6 +505,8 @@ class Installation:
     # endregion
 
     def game(self) -> Game:
+        if self._game:
+            return self._game
         path = self._path
         def check(x):
             return path.joinpath(x).exists()
@@ -516,10 +519,11 @@ class Installation:
         is_game2_exe = check("swkotor2.exe") and not check("swkotor.exe")
 
         if any([is_game2_stream, is_game2_exe]):
-            return Game(2)
+            self._game = Game(2)
         if any([is_game1_stream, is_game1_exe, is_game1_rims]):
-            return Game(1)
-
+            self._game = Game(1)
+        if self._game is not None:
+            return self._game
         msg = "Could not find the game executable!"
         raise ValueError(msg)
 

--- a/pykotor/extract/installation.py
+++ b/pykotor/extract/installation.py
@@ -269,99 +269,13 @@ class Installation:
 
     # region Load Data
 
-    def load_chitin(self) -> None:
-        """Reloads the list of resources in the Chitin linked to the Installation."""
-        if not self._path.joinpath("chitin.key").exists():
-            self.log.add_warning(f"The chitin.key file did not exist at '{self._path!s}' when loading the installation, skipping...")
-            return
-        chitin = Chitin(self._path)
-        self._chitin = list(chitin)
-
-    def load_rims(
-        self,
-    ) -> None:
-        """Reloads the list of module files in the rims folder linked to the Installation."""
-        self._rims = self.load_resources(  # type: ignore[always a dict]
-            self.rims_path(),
-            capsule_check=is_rim_file,
-            recurse=False,
-        )
-
-    def load_modules(self) -> None:
-        """Reloads the list of modules files in the modules folder linked to the Installation."""
-        self._modules = self.load_resources(  # type: ignore[always a dict]
-            self.module_path(),
-            capsule_check=is_capsule_file,
-            recurse=False,
-        )
-    def reload_module(self, module: str) -> None:
-        """Reloads the list of resources in specified module in the modules folder linked to the Installation.
-
-        Args:
-        ----
-            module: The filename of the module.
-        """
-        self._modules[module] = list(Capsule(self.module_path() / module))
-
-    def load_lips(
-        self,
-    ) -> None:
-        """Reloads the list of modules in the lips folder linked to the Installation."""
-        self._lips = self.load_resources(  # type: ignore[always a dict]
-            self.lips_path(),
-            capsule_check=is_mod_file,
-            recurse=False,
-        )
-
-    def load_textures(
-        self,
-    ) -> None:
-        """Reloads the list of modules files in the texturepacks folder linked to the Installation."""
-        self._texturepacks = self.load_resources(  # type: ignore[always a dict]
-            self.texturepacks_path(),
-            capsule_check=is_erf_file,
-            recurse=False,
-        )
-
-
-    def load_override(self, directory: str | None = None) -> None:
-        """Loads the list of resources in a specific subdirectory of the override folder linked to the Installation.
-        If a directory argument is not passed, this will reload all subdirectories in the Override folder.
-        If directory argument is ".", this will load all the loose files in the Override folder.
-
-        the _override dict follows the following example format:
-        _override["."] = list[FileResource]  # the loose files in the Override folder
-        _override["subdir1"] = list[FileResource]  # the loose files in subdir1
-        _override["subdir2"] = list[FileResource]  # the loose files in subdir2
-        _override["subdir1/subdir3"] = list[FileResource]  # the loose files in subdir1/subdir3. Key is always a posix path (delimited by /'s)
-
-        Args:
-        ----
-            directory: The subdirectory in the override folder.
-        """
-        override_path = self.override_path()
-        if directory is not None:
-            target_dirs = [override_path / directory]
-            self._override[directory] = []
-        else:
-            target_dirs = [f for f in override_path.safe_rglob("*") if f.safe_isdir()]
-            target_dirs.append(override_path)
-            self._override = {}
-
-        for folder in target_dirs:
-            relative_folder = folder.relative_to(override_path).as_posix()  # '.' if folder is the same as override_path
-            self._override[relative_folder] = self.load_resources(
-                folder,
-                recurse=False,  # we already are recursing here in load_override
-            )
-
-    def load_resources(self, path: os.PathLike | str, capsule_check=None, recurse=True) -> dict[str, list[FileResource]] | list[FileResource]:
+    def load_resources(self, path: os.PathLike | str, capsule_check=None, recurse=False) -> dict[str, list[FileResource]] | list[FileResource]:
         """Load resources for a given path and store them in the provided list.
 
         Args:
         ----
             path_method (os.PathLike | str): path for lookup.
-            recurse (bool): whether to recurse into subfolders (default is True)
+            recurse (bool): whether to recurse into subfolders (default is False)
 
         Returns:
         -------
@@ -377,46 +291,99 @@ class Installation:
             return resources
 
         files_list: list[CaseAwarePath] = list(c_path.safe_rglob("*")) if recurse else list(c_path.safe_iterdir())
-
         for file in files_list:
             if capsule_check and capsule_check(file.name):
                 resources[file.name] = list(Capsule(file))  # type: ignore[always a dict]
-                continue
-
-            with suppress(Exception):
-                identifier = ResourceIdentifier.from_path(file)
-                resource = FileResource(
-                    identifier.resname,
-                    identifier.restype,
-                    file.stat().st_size,
-                    0,
-                    file,
-                )
-                resources.append(resource)  # type: ignore[always a list]
+            else:
+                with suppress(Exception):
+                    resource = FileResource(
+                        *ResourceIdentifier.from_path(file),
+                        file.stat().st_size,
+                        0,
+                        file,
+                    )
+                    resources.append(resource)  # type: ignore[always a list]
         if not resources or not files_list:
             self.log.add_warning(f"No resources found at '{c_path!s}' when loading the installation, skipping...")
         return resources
 
+    def load_chitin(self) -> None:
+        """Reloads the list of resources in the Chitin linked to the Installation."""
+        if not self._path.joinpath("chitin.key").exists():
+            self.log.add_warning(f"The chitin.key file did not exist at '{self._path!s}' when loading the installation, skipping...")
+            return
+        self._chitin = list(Chitin(kotor_path=self._path))
+
+    def load_lips(
+        self,
+    ) -> None:
+        """Reloads the list of modules in the lips folder linked to the Installation."""
+        self._lips = self.load_resources(self.lips_path(), capsule_check=is_mod_file)  # type: ignore[always a dict]
+
+    def load_modules(self) -> None:
+        """Reloads the list of modules files in the modules folder linked to the Installation."""
+        self._modules = self.load_resources(self.module_path(), capsule_check=is_capsule_file)  # type: ignore[always a dict]
+    def reload_module(self, module: str) -> None:
+        """Reloads the list of resources in specified module in the modules folder linked to the Installation.
+
+        Args:
+        ----
+            module: The filename of the module.
+        """
+        self._modules[module] = list(Capsule(self.module_path() / module))
+
+    def load_rims(
+        self,
+    ) -> None:
+        """Reloads the list of module files in the rims folder linked to the Installation."""
+        self._rims = self.load_resources(self.rims_path(), capsule_check=is_rim_file)  # type: ignore[always a dict]
+
+    def load_textures(
+        self,
+    ) -> None:
+        """Reloads the list of modules files in the texturepacks folder linked to the Installation."""
+        self._texturepacks = self.load_resources(self.texturepacks_path(), capsule_check=is_erf_file)  # type: ignore[always a dict]
+
+
+    def load_override(self, directory: str | None = None) -> None:
+        """Loads the list of resources in a specific subdirectory of the override folder linked to the Installation.
+        If a directory argument is not passed, this will reload all subdirectories in the Override folder.
+        If directory argument is ".", this will load all the loose files in the Override folder.
+
+        the _override dict follows the following example format:
+        _override["."] = list[FileResource]  # the loose files in the Override folder
+        _override["subdir1"] = list[FileResource]  # the loose files in subdir1
+        _override["subdir2"] = list[FileResource]  # the loose files in subdir2
+        _override["subdir1/subdir3"] = list[FileResource]  # the loose files in subdir1/subdir3. Key is always a posix path (delimited by /'s)
+
+        Args:
+        ----
+            directory: The relative path of a subfolder to the override folder.
+        """
+        override_path = self.override_path()
+        if directory:
+            target_dirs = [override_path / directory]
+            self._override[directory] = []
+        else:
+            target_dirs = [f for f in override_path.safe_rglob("*") if f.safe_isdir()]
+            target_dirs.append(override_path)
+            self._override = {}
+
+        for folder in target_dirs:
+            relative_folder = folder.relative_to(override_path).as_posix()  # '.' if folder is the same as override_path
+            self._override[relative_folder] = self.load_resources(folder)  # type: ignore[always a list]
+
     def load_streammusic(self) -> None:
         """Reloads the list of resources in the streammusic folder linked to the Installation."""
-        self._streammusic = self.load_resources(  # type: ignore[always a list]
-            self.streammusic_path(),
-            recurse=False,
-        )
+        self._streammusic = self.load_resources(self.streammusic_path())  # type: ignore[always a list]
 
     def load_streamsounds(self) -> None:
         """Reloads the list of resources in the streamsounds folder linked to the Installation."""
-        self._streamsounds = self.load_resources(  # type: ignore[always a list]
-            self.streamsounds_path(),
-            recurse=False,
-        )
+        self._streamsounds = self.load_resources(self.streamsounds_path())  # type: ignore[always a list]
 
     def load_streamwaves(self) -> None:
         """Reloads the list of resources in the streamvoice/streamwaves folder linked to the Installation."""
-        self._streamwaves = self.load_resources(  # type: ignore[always a list]
-            self.streamwaves_path(),
-            recurse=True,
-        )
+        self._streamwaves = self.load_resources(self.streamwaves_path(), recurse=True)  # type: ignore[always a list]
 
     # endregion
 
@@ -602,8 +569,13 @@ class Installation:
             capsules=capsules,
             folders=folders,
         )
+        search = batch[query]
+        if not search or not search.data:
+            self.log.add_error(
+                f"Could not find '{resname}.{restype}' during resource lookup.",
+            )
 
-        return batch[query] or None
+        return None
 
     def resources(
         self,

--- a/pykotor/tools/misc.py
+++ b/pykotor/tools/misc.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import hashlib
 import re
+from typing import TYPE_CHECKING
 
-from pykotor.tools.path import CaseAwarePath
+from pykotor.tools.path import Path
+
+if TYPE_CHECKING:
+    import os
 
 
-def generate_filehash_sha256(filepath: str | CaseAwarePath) -> str:
+def generate_filehash_sha256(filepath: os.PathLike | str) -> str:
     sha1_hash = hashlib.sha256()
-    filepath = filepath if isinstance(filepath, CaseAwarePath) else CaseAwarePath(filepath)
+    filepath = filepath if isinstance(filepath, Path) else Path(filepath)
     with filepath.open("rb") as f:
         data = f.read(65536)
         while data:  # read in 64k chunks
@@ -95,7 +99,7 @@ def case_insensitive_replace(s: str, old: str, new: str) -> str:
 def striprtf(text):
     """Strips RTF encoding utterly and completely."""
     pattern = re.compile(r"\\([a-z]{1,32})(-?\d{1,10})?[ ]?|\\'([0-9a-f]{2})|\\([^a-z])|([{}])|[\r\n]+|(.)", re.I)
-    # control words which specify a "destionation".
+    # control words which specify a "destination".
     destinations = frozenset(
         (
             "aftncn",

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -42,6 +42,7 @@ from pykotor.tslpatcher.mods.tlk import ModificationsTLK
 
 if TYPE_CHECKING:
     import os
+    from pathlib import Path
 
     from pykotor.resource.formats.twoda.twoda_data import TwoDA
     from pykotor.tslpatcher.mods.gff import ModificationsGFF
@@ -147,6 +148,9 @@ class ModInstaller:
                 raise FileNotFoundError(msg)
 
         self._config: PatcherConfig | None = None
+        self._installation: Installation | None = None
+        self._backup: CaseAwarePath | None = None
+        self._processed_backup_files: set = set()
 
     def config(self) -> PatcherConfig:
         """Returns the PatcherConfig object associated with the mod installer. The object is created when the method is
@@ -187,7 +191,17 @@ class ModInstaller:
         self._config = PatcherConfig()
         self._config.load(ini_text, self.mod_path, self.log)
 
+        if self._config.required_file:
+            requiredfile_path = self.game_path / "Override" / self._config.required_file
+            if not requiredfile_path.exists():
+                raise ImportError(self._config.required_message.strip() or "cannot install - missing a required mod")
         return self._config
+
+    def installation(self):
+        if self._installation:
+            return self._installation
+        self._installation = Installation(self.game_path, self.log)
+        return self._installation
 
     def game(self) -> Game:
         if (self.game_path.joinpath("streamvoice").exists() or self.game_path.joinpath("swkotor2.exe")):
@@ -197,7 +211,9 @@ class ModInstaller:
         msg = "Could not determine which KOTOR game to load!"
         raise ValueError(msg)
 
-    def initialize_backup(self) -> CaseAwarePath:
+    def backup(self) -> tuple[CaseAwarePath, set]:
+        if self._backup:
+            return (self._backup, self._processed_backup_files)
         backup_dir = self.mod_path
         timestamp = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d_%H.%M.%S")
         while not backup_dir.joinpath("tslpatchdata").exists() and backup_dir.parent.name:
@@ -214,34 +230,96 @@ class ModInstaller:
         except PermissionError as e:
             self.log.add_warning(f"Could not create backup folder: {e}")
         self.log.add_note(f"Using backup directory: '{backup_dir}'")
-        return backup_dir
+        self._backup = backup_dir
+        self._processed_backup_files = set()
+        return (self._backup, self._processed_backup_files)
+
+    def get_patch_paths(self, patch) -> tuple[CaseAwarePath, CaseAwarePath]:
+        output_container_path: CaseAwarePath = self.game_path / patch.destination
+        return output_container_path, output_container_path.relative_to(self.game_path)
+
+    def handle_capsule_and_backup(self, patch, output_container_path: CaseAwarePath, rel_output_container_path: CaseAwarePath) -> Capsule | None:
+        capsule = None
+        if is_capsule_file(patch.destination):
+            capsule = Capsule(output_container_path)
+            create_backup(self.log, output_container_path, *self.backup(), rel_output_container_path.parent)
+        else:
+            create_backup(self.log, output_container_path.joinpath(patch.filename), *self.backup(), rel_output_container_path)
+        return capsule
+
+    def lookup_resource(self, patch, capsule=None):
+        return self.installation().resource(
+            *ResourceIdentifier.from_path(patch.filename),
+            [SearchLocation.CUSTOM_FOLDERS] if hasattr(patch, "replace_file") and patch.replace_file else [SearchLocation.CUSTOM_MODULES, SearchLocation.OVERRIDE, SearchLocation.CUSTOM_FOLDERS],
+            capsules=[capsule] if capsule else [],
+            folders=[self.mod_path],
+        )
+
+    def do_patchlist(self, patch_list, section_name, game=None):
+        self.log.add_note(f"Applying {len(patch_list)} patches from [{section_name}]...")
+        for patch in patch_list:
+            output_container_path, rel_output_container_path = self.get_patch_paths(patch)
+            capsule = self.handle_capsule_and_backup(patch, output_container_path, rel_output_container_path)
+            search = self.lookup_resource(patch, capsule)
+            if not search:
+                continue
+            data = self.load_data(search, patch)
+            self.save_data(data, patch, memory, output_container_path, game)
+            self.log.complete_patch()
+
 
     def install(self) -> None:
         config = self.config()
-        if config.required_file:
-            requiredfile_path = self.game_path / "Override" / config.required_file
-            if not requiredfile_path.exists():
-                raise ImportError(config.required_message.strip() or "cannot install - missing a required mod")
-
-        installation = Installation(self.game_path, self.log)
+        installation = self.installation()
         memory = PatcherMemory()
 
-        # Create a timestamped backup directory
-        backup_dir = self.initialize_backup()
-        processed_files = set()
+        def should_patch(
+            patch,
+            exists: bool = False,
+            subdir: Path | None = None,
+            capsule: Capsule | None = None,
+            no_replacefile_check: bool | None = None,  # !ReplaceFile handled differently in lookup_resource for GFFList and SSFList
+            action: str = "Patching",
+        ):
+            local_folder = subdir or patch.destination
+            if local_folder == ".":
+                local_folder = self.game_path.name
+            container_type = "folder" if capsule is None else "archive"
+            is_replaceable = hasattr(patch, "replace_file")
+            replace_file = is_replaceable and patch.replace_file or no_replacefile_check
+
+            if replace_file and exists:
+                if capsule:
+                    self.log.add_note(f"{action} '{patch.filename}' and replacing existing resource in the '{local_folder}' archive")
+                else:
+                    self.log.add_note(f"{action} '{patch.filename}' and replacing existing file in the '{local_folder}' folder")
+            elif exists and is_replaceable:
+                if capsule and not capsule._path.exists():
+                    self.log.add_error(f"The capsule '{rel_output_container_path}' did not exist when attempting to patch GFF '{patch.filename}'. Skipping file...")
+                else:
+                    self.log.add_warning(f"'{patch.filename}' already exists in the '{local_folder}' {container_type}. Skipping file...")
+                return False
+            else:
+                self.log.add_note(f"{action} '{patch.filename}' and {'adding' if capsule else 'saving'} to the '{local_folder}' {container_type}")
+            return True
 
         self.log.add_note(f"Applying {len(config.patches_tlk.modifiers)} patches from [TLKList]...")
         if len(config.patches_tlk.modifiers) > 0:  # skip if no patches need to be made (faster)
-            # sourcery skip: extract-method, move-assign-in-block, use-fstring-for-concatenation
-            dialog_tlk_path = self.game_path.joinpath("dialog.tlk")
+            # def get_patch_paths
+            output_container_path, rel_output_container_path = self.get_patch_paths(config.patches_tlk)
+            dialog_tlk_path = output_container_path.joinpath(config.patches_tlk.filename)
 
-            create_backup(self.log, dialog_tlk_path, backup_dir, processed_files)
+            # def handle_encapsulated
+            create_backup(self.log, dialog_tlk_path, *self.backup())
+            should_patch(config.patches_tlk)
 
-            self.log.add_note("Patching 'dialog.tlk'...")
+            # def lookup_resource --> returns search (None for patches_tlk)
+            # def load_data --> returns dialog_tlk
             dialog_tlk = read_tlk(dialog_tlk_path)
 
+            # def save_data
             config.patches_tlk.apply(dialog_tlk, memory)
-            write_tlk(dialog_tlk, dialog_tlk_path, strip_soundlength=self.game() == Game.K2)
+            write_tlk(dialog_tlk, dialog_tlk_path)
             self.log.complete_patch()
 
         # Move nwscript.nss to Override if there are any nss patches to do
@@ -254,121 +332,108 @@ class ModInstaller:
 
         self.log.add_note(f"Applying {len(config.install_list)} patches from [InstallList]...")
         for folder in config.install_list:
-            folder.apply(self.log, self.mod_path, self.game_path, backup_dir, processed_files)
+            folder.apply(self.log, self.mod_path, self.game_path, *self.backup())
             self.log.complete_patch()
 
         self.log.add_note(f"Applying {len(config.patches_2da)} patches from [2DAList]...")
-        for twoda_patch in config.patches_2da:
-            twoda_output_filepath = self.game_path / "Override" / twoda_patch.filename
+        for patch in config.patches_2da:
+            output_container_path, rel_output_container_path = self.get_patch_paths(patch)
+            output_file_path = output_container_path.joinpath(patch.filename)
 
-            create_backup(self.log, twoda_output_filepath, backup_dir, processed_files, subdirectory_path="Override")
+            create_backup(self.log, output_file_path, *self.backup(), rel_output_container_path)
+            should_patch(patch, output_file_path.exists())
 
-            self.log.add_note(f"Patching '{twoda_patch.filename}' in the 'Override' folder.")
-            search = installation.resource(
-                *ResourceIdentifier.from_path(twoda_patch.filename),
-                [SearchLocation.OVERRIDE, SearchLocation.CUSTOM_FOLDERS],
-                folders=[self.mod_path],
-            )
-            if search is None:
+            search = self.lookup_resource(patch)
+            if not search:
                 continue
-            twoda: TwoDA = read_2da(search.data)
 
-            twoda_patch.apply(twoda, memory)
-            write_2da(twoda, twoda_output_filepath)
+            template = read_2da(search.data)
+            patch.apply(template, memory)
+            write_2da(template, output_file_path)
             self.log.complete_patch()
 
         self.log.add_note(f"Applying {len(config.patches_gff)} patches from [GFFList]...")
-        for gff_patch in config.patches_gff:
-            gff_output_container_path = self.game_path / gff_patch.destination
-            rel_output_container_path = gff_output_container_path.relative_to(self.game_path)
+        for patch in config.patches_gff:
+            output_container_path, rel_output_container_path = self.get_patch_paths(patch)
             capsule: Capsule | None = None
+            exists: bool | None = None
 
-            if is_capsule_file(gff_patch.destination.name):
-                capsule = Capsule(gff_output_container_path)
-                create_backup(self.log, gff_output_container_path, backup_dir, processed_files, rel_output_container_path.parent)
-                if not capsule._path.exists():
-                    self.log.add_error(
-                        f"The capsule '{rel_output_container_path}' did not exist when patching GFF '{gff_patch.filename}'."
-                        " This most likely indicates a different problem existed beforehand, such as a missing mod dependency.",
-                    )
+            if is_capsule_file(patch.destination):
+                capsule = Capsule(output_container_path)
+                create_backup(self.log, output_container_path, *self.backup(), rel_output_container_path.parent)
+                exists = capsule.exists(*ResourceIdentifier.from_path(patch.filename))
             else:
-                create_backup(self.log, gff_output_container_path.joinpath(gff_patch.filename), backup_dir, processed_files, rel_output_container_path)
+                create_backup(self.log, output_container_path.joinpath(patch.filename), *self.backup(), rel_output_container_path)
+                exists = output_container_path.joinpath(patch.filename).exists()
 
-            self.log.add_note(f"Patching '{gff_patch.filename}' in the '{rel_output_container_path}' folder.")
-            search = installation.resource(
-                *ResourceIdentifier.from_path(gff_patch.filename),
-                [SearchLocation.CUSTOM_FOLDERS] if gff_patch.replace_file else [SearchLocation.CUSTOM_MODULES, SearchLocation.OVERRIDE, SearchLocation.CUSTOM_FOLDERS],
-                capsules=[capsule] if capsule else [],
-                folders=[self.mod_path],
-            )
+            should_patch(patch, exists, rel_output_container_path, capsule, no_replacefile_check=True)
+
+            search = self.lookup_resource(patch, capsule)
             if not search:
                 continue
-            template = read_gff(search.data)
 
-            gff_patch.apply(template, memory, self.log)
-            self.write(gff_output_container_path, gff_patch.filename, bytes_gff(template), replace=True)
+            template = read_gff(search.data)
+            patch.apply(template, memory, self.log)
+            self.write(output_container_path, patch.filename, bytes_gff(template))
             self.log.complete_patch()
 
         self.log.add_note(f"Applying {len(config.patches_nss)} patches from [CompileList]...")
-        for nss_patch in config.patches_nss:
-            nss_output_container_path: CaseAwarePath = self.game_path / nss_patch.destination
-            rel_output_container_path: CaseAwarePath = nss_output_container_path.relative_to(self.game_path)
-            ncs_compiled_filename = f"{nss_patch.filename.rsplit('.', 1)[0]}.ncs"
+        for patch in config.patches_nss:
+            output_container_path, rel_output_container_path = self.get_patch_paths(patch)
+            ncs_compiled_filename = f"{patch.filename.rsplit('.', 1)[0]}.ncs"
 
-            if is_capsule_file(nss_output_container_path.name):
-                create_backup(self.log, nss_output_container_path, backup_dir, processed_files, rel_output_container_path.parent)
-                if not nss_output_container_path.exists():
-                    self.log.add_error(
-                        f"The capsule '{rel_output_container_path}' did not exist when compiling NSS '{nss_patch.filename}'."
-                        " This most likely indicates a different problem existed beforehand, such as a missing mod dependency.",
-                    )
-            else:
-                create_backup(self.log, nss_output_container_path.joinpath(nss_patch.filename), backup_dir, processed_files, rel_output_container_path)
+            create_backup(self.log, output_container_path.joinpath(patch.filename), *self.backup(), rel_output_container_path)
+            if not should_patch(
+                patch,
+                output_container_path.joinpath(ncs_compiled_filename).exists(),
+                rel_output_container_path,
+                action="Compiling",
+            ):
+                continue
 
-            self.log.add_note(f"Compiling '{nss_patch.filename}' and saving to '{rel_output_container_path / ncs_compiled_filename}'")
-            nss_bytes = BinaryReader.load_file(self.mod_path / nss_patch.filename)
+            nss_bytes = BinaryReader.load_file(self.mod_path / patch.filename)
             encoding: str = (chardet and chardet.detect(nss_bytes) or {}).get("encoding") or "utf8"
-            nss: list[str] = [nss_bytes.decode(encoding=encoding, errors="replace")]
+            template = [nss_bytes.decode(encoding=encoding, errors="replace")]
 
-            nss_patch.apply(nss, memory, self.log)
-            self.write(nss_output_container_path, ncs_compiled_filename, bytes_ncs(compile_nss(nss[0], installation.game())), nss_patch.replace_file)
+            patch.apply(template, memory, self.log)
+            self.write(output_container_path, ncs_compiled_filename, bytes_ncs(compile_nss(template[0], installation.game())))
             self.log.complete_patch()
 
         self.log.add_note(f"Applying {len(config.patches_ssf)} patches from [SSFList]...")
-        for ssf_patch in config.patches_ssf:
-            ssf_output_filepath: CaseAwarePath = self.game_path / "Override" / ssf_patch.filename
+        for patch in config.patches_ssf:
+            output_container_path, rel_output_container_path = self.get_patch_paths(patch)
+            output_file_path = output_container_path.joinpath(patch.filename)
 
-            create_backup(self.log, ssf_output_filepath, backup_dir, processed_files, "Override")
+            create_backup(self.log, output_file_path, *self.backup(), rel_output_container_path)
+            should_patch(patch, output_file_path.exists(), rel_output_container_path, no_replacefile_check=True)
 
-            self.log.add_note(f"Patching '{ssf_patch.filename}' in the 'Override' folder.")
-            search = installation.resource(
-                *ResourceIdentifier.from_path(ssf_patch.filename),
-                [SearchLocation.CUSTOM_FOLDERS] if ssf_patch.replace_file else [SearchLocation.OVERRIDE, SearchLocation.CUSTOM_FOLDERS],
-                folders=[self.mod_path],
-            )
-            if search is None:
+            search = self.lookup_resource(patch)
+            if not search:
                 continue
-            soundset = read_ssf(search.data)
 
-            ssf_patch.apply(soundset, memory)
-            write_ssf(soundset, ssf_output_filepath)
+            template = read_ssf(search.data)
+            patch.apply(template, memory)
+            write_ssf(template, output_file_path)
             self.log.complete_patch()
 
-    def write(self, destination: CaseAwarePath, filename: str, data: bytes, replace: bool = False) -> None:
-        resname, restype = ResourceIdentifier.from_path(filename)
+        self.log.add_note(f"Successfully completed {self.log.patches_completed} total patches.")
+
+    def write(self, destination: CaseAwarePath, filename: str, data: bytes) -> None:
         if is_rim_file(destination.name):
-            rim = read_rim(BinaryReader.load_file(destination)) if destination.exists() else RIM()
-            if not rim.get(resname, restype) or replace:
-                rim.set_data(resname, restype, data)
-                write_rim(rim, destination)
+            rim = (
+                read_rim(BinaryReader.load_file(destination))
+                if destination.exists()
+                else RIM()
+            )
+            rim.set_data(*ResourceIdentifier.from_path(filename), data)
+            write_rim(rim, destination)
         elif is_erf_or_mod_file(destination.name):
             erf = (
                 read_erf(BinaryReader.load_file(destination))
                 if destination.exists()
                 else ERF(ERFType.from_extension(destination.name))
             )
-            if not erf.get(resname, restype) or replace:
-                erf.set_data(resname, restype, data)
-                write_erf(erf, destination)
-        elif not (destination / filename).exists() or replace:
+            erf.set_data(*ResourceIdentifier.from_path(filename), data)
+            write_erf(erf, destination)
+        else:
             BinaryWriter.dump(destination / filename, data)

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -276,21 +276,20 @@ class ModInstaller:
             action = patch.action if hasattr(patch, "action") else "Patch "
 
             if replace_file and exists:
-                if capsule:
+                if capsule is not None:
                     self.log.add_note(f"{action[:-1]}ing '{patch.filename}' and replacing existing resource in the '{local_folder}' archive")
                 else:
                     self.log.add_note(f"{action[:-1]}ing '{patch.filename}' and replacing existing file in the '{local_folder}' folder")
             elif no_replacefile_check and exists:
-                if capsule:
+                if capsule is not None:
                     self.log.add_note(f"{action[:-1]}ing existing resource '{patch.filename}' in the '{local_folder}' archive")
                 else:
                     self.log.add_note(f"{action[:-1]}ing existing file '{patch.filename}' in the '{local_folder}' folder")
             elif is_replaceable and exists:
-                if capsule and not capsule._path.exists():
-                    self.log.add_error(f"The capsule '{patch.destination}' did not exist when attempting to {action.lower()} '{patch.filename}'. Skipping file...")
-                else:
-                    self.log.add_warning(f"'{patch.filename}' already exists in the '{local_folder}' {container_type}. Skipping file...")
+                self.log.add_warning(f"'{patch.filename}' already exists in the '{local_folder}' {container_type}. Skipping file...")
                 return False
+            elif capsule is not None and not capsule._path.exists():
+                self.log.add_error(f"The capsule '{patch.destination}' did not exist when attempting to {action.lower().rstrip()} '{patch.filename}'. Skipping file...")
             else:
                 self.log.add_note(f"{action[:-1]}ing '{patch.filename}' and {'adding' if capsule else 'saving'} to the '{local_folder}' {container_type}")
             return True

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -301,11 +301,11 @@ class ModInstaller:
             dialog_tlk_path = output_container_path.joinpath(patch.filename)
 
             create_backup(self.log, dialog_tlk_path, *self.backup())
-            should_patch(config.patches_tlk)
+            should_patch(patch, dialog_tlk_path.exists())
 
             dialog_tlk = read_tlk(dialog_tlk_path)
 
-            config.patches_tlk.apply(dialog_tlk, memory)
+            patch.apply(dialog_tlk, memory)
             write_tlk(dialog_tlk, dialog_tlk_path)
             self.log.complete_patch()
 

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -296,18 +296,14 @@ class ModInstaller:
 
         self.log.add_note(f"Applying {len(config.patches_tlk.modifiers)} patches from [TLKList]...")
         if len(config.patches_tlk.modifiers) > 0:  # skip if no patches need to be made (faster)
-            # def get_patch_paths
-            dialog_tlk_path = self.game_path.joinpath(config.patches_tlk.filename)
+            output_container_path = self.game_path / config.patches_tlk.destination
+            dialog_tlk_path = output_container_path.joinpath(config.patches_tlk.filename)
 
-            # def handle_encapsulated
             create_backup(self.log, dialog_tlk_path, *self.backup())
             should_patch(config.patches_tlk)
 
-            # def lookup_resource --> returns search (None for patches_tlk)
-            # def load_data --> returns dialog_tlk
             dialog_tlk = read_tlk(dialog_tlk_path)
 
-            # def save_data
             config.patches_tlk.apply(dialog_tlk, memory)
             write_tlk(dialog_tlk, dialog_tlk_path)
             self.log.complete_patch()

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -296,8 +296,9 @@ class ModInstaller:
 
         self.log.add_note(f"Applying {len(config.patches_tlk.modifiers)} patches from [TLKList]...")
         if len(config.patches_tlk.modifiers) > 0:  # skip if no patches need to be made (faster)
-            output_container_path = self.game_path / config.patches_tlk.destination
-            dialog_tlk_path = output_container_path.joinpath(config.patches_tlk.filename)
+            patch = config.patches_tlk
+            output_container_path = self.game_path / patch.destination
+            dialog_tlk_path = output_container_path.joinpath(patch.filename)
 
             create_backup(self.log, dialog_tlk_path, *self.backup())
             should_patch(config.patches_tlk)

--- a/pykotor/tslpatcher/config.py
+++ b/pykotor/tslpatcher/config.py
@@ -246,18 +246,6 @@ class ModInstaller:
             folders=[self.mod_path],
         )
 
-    def do_patchlist(self, patch_list, section_name, game=None):
-        self.log.add_note(f"Applying {len(patch_list)} patches from [{section_name}]...")
-        for patch in patch_list:
-            output_container_path = self.game_path / patch.destination
-            capsule = self.handle_capsule_and_backup(patch, output_container_path)
-            search = self.lookup_resource(patch, capsule)
-            if not search:
-                continue
-            data = self.load_data(search, patch)
-            self.save_data(data, patch, memory, output_container_path, game)
-            self.log.complete_patch()
-
     def install(self) -> None:
         config = self.config()
         memory = PatcherMemory()
@@ -290,6 +278,7 @@ class ModInstaller:
                 return False
             elif capsule is not None and not capsule._path.exists():
                 self.log.add_error(f"The capsule '{patch.destination}' did not exist when attempting to {action.lower().rstrip()} '{patch.filename}'. Skipping file...")
+                return False
             else:
                 self.log.add_note(f"{action[:-1]}ing '{patch.filename}' and {'adding' if capsule else 'saving'} to the '{local_folder}' {container_type}")
             return True

--- a/pykotor/tslpatcher/mods/gff.py
+++ b/pykotor/tslpatcher/mods/gff.py
@@ -343,17 +343,11 @@ class ModificationsGFF:
         filename: str,
         replace_file: bool,
         modifiers: list[ModifyGFF] | None = None,
-        destination: str | CaseAwarePath | None = None,
+        destination: str | None = None,
     ) -> None:
         self.filename: str = filename
         self.replace_file: bool = replace_file
-        if destination is None:
-            self.destination = CaseAwarePath("Override")
-        elif not isinstance(destination, CaseAwarePath):
-            self.destination = CaseAwarePath(destination)
-        else:
-            self.destination = destination
-
+        self.destination = destination or "Override"
         self.modifiers: list[ModifyGFF] = modifiers if modifiers is not None else []
 
     def apply(

--- a/pykotor/tslpatcher/mods/gff.py
+++ b/pykotor/tslpatcher/mods/gff.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Any, Callable
 from pykotor.common.language import LocalizedString
 from pykotor.common.misc import ResRef
 from pykotor.resource.formats.gff import GFF, GFFFieldType, GFFList, GFFStruct
-from pykotor.tools.path import CaseAwarePath, PureWindowsPath
+from pykotor.resource.formats.gff.gff_auto import bytes_gff, read_gff
+from pykotor.tools.path import PureWindowsPath
 
 if TYPE_CHECKING:
     from pykotor.resource.formats.gff.gff_data import _GFFField
@@ -347,14 +348,17 @@ class ModificationsGFF:
     ) -> None:
         self.filename: str = filename
         self.replace_file: bool = replace_file
+        self.no_replacefile_check = True
         self.destination = destination or "Override"
         self.modifiers: list[ModifyGFF] = modifiers if modifiers is not None else []
 
     def apply(
         self,
-        gff: GFF,
+        gff_bytes: bytes,
         memory: PatcherMemory,
         logger: PatchLogger,
-    ) -> None:
+    ) -> bytes:
+        gff: GFF = read_gff(gff_bytes)
         for change_field in self.modifiers:
             change_field.apply(gff.root, memory, logger)
+        return bytes_gff(gff)

--- a/pykotor/tslpatcher/mods/gff.py
+++ b/pykotor/tslpatcher/mods/gff.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, Callable
 
 from pykotor.common.language import LocalizedString
-from pykotor.common.misc import ResRef
+from pykotor.common.misc import Game, ResRef
 from pykotor.resource.formats.gff import GFF, GFFFieldType, GFFList, GFFStruct
 from pykotor.resource.formats.gff.gff_auto import bytes_gff, read_gff
 from pykotor.tools.path import PureWindowsPath
@@ -357,6 +357,7 @@ class ModificationsGFF:
         gff_bytes: bytes,
         memory: PatcherMemory,
         logger: PatchLogger,
+        game: Game,
     ) -> bytes:
         gff: GFF = read_gff(gff_bytes)
         for change_field in self.modifiers:

--- a/pykotor/tslpatcher/mods/nss.py
+++ b/pykotor/tslpatcher/mods/nss.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+import chardet
+
+from pykotor.resource.formats.ncs.ncs_auto import bytes_ncs, compile_nss
+
 if TYPE_CHECKING:
+    from pykotor.common.misc import Game
     from pykotor.tslpatcher.logger import PatchLogger
     from pykotor.tslpatcher.memory import PatcherMemory
 
@@ -12,23 +17,25 @@ class ModificationsNSS:
     def __init__(self, filename: str, replace_file: bool):
         self.filename: str = filename
         self.destination: str = "Override"
+        self.action: str = "Compile"
         self.replace_file: bool = replace_file
 
-    def apply(self, nss: list[str], memory: PatcherMemory, logger: PatchLogger) -> None:
-        source = nss[0]
+    def apply(self, nss_bytes: bytes, memory: PatcherMemory, logger: PatchLogger, game: Game) -> bytes:
+        encoding: str = (chardet and chardet.detect(nss_bytes) or {}).get("encoding") or "utf8"
+        source = nss_bytes.decode(encoding=encoding, errors="replace")
 
         match = re.search(r"#2DAMEMORY\d+#", source)
         while match:
             token_id = int(source[match.start() + 10 : match.end() - 1])
             value = memory.memory_2da[token_id]
-            source = source[0 : match.start()] + str(value) + source[match.end() : len(source)]
+            source = source[: match.start()] + str(value) + source[match.end() :]
             match = re.search(r"#2DAMEMORY\d+#", source)
 
         match = re.search(r"#StrRef\d+#", source)
         while match:
             token_id = int(source[match.start() + 7 : match.end() - 1])
             value = memory.memory_str[token_id]
-            source = source[0 : match.start()] + str(value) + source[match.end() : len(source)]
+            source = source[: match.start()] + str(value) + source[match.end() :]
             match = re.search(r"#StrRef\d+#", source)
 
-        nss[0] = source
+        return bytes_ncs(compile_nss(source, game))

--- a/pykotor/tslpatcher/mods/nss.py
+++ b/pykotor/tslpatcher/mods/nss.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import chardet
 
 from pykotor.resource.formats.ncs.ncs_auto import bytes_ncs, compile_nss
+from pykotor.tools.path import PurePath
 
 if TYPE_CHECKING:
     from pykotor.common.misc import Game
@@ -38,4 +39,5 @@ class ModificationsNSS:
             source = source[: match.start()] + str(value) + source[match.end() :]
             match = re.search(r"#StrRef\d+#", source)
 
+        self.filename = str(PurePath(self.filename).with_suffix(".ncs"))
         return bytes_ncs(compile_nss(source, game))

--- a/pykotor/tslpatcher/mods/ssf.py
+++ b/pykotor/tslpatcher/mods/ssf.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING
 from pykotor.resource.formats.ssf.ssf_auto import bytes_ssf, read_ssf
 
 if TYPE_CHECKING:
+    from pykotor.common.misc import Game
     from pykotor.resource.formats.ssf import SSF, SSFSound
+    from pykotor.tslpatcher.logger import PatchLogger
     from pykotor.tslpatcher.memory import PatcherMemory, TokenUsage
 
 
@@ -31,7 +33,7 @@ class ModificationsSSF:
         self.no_replacefile_check = True
         self.modifiers: list[ModifySSF] = modifiers if modifiers is not None else []
 
-    def apply(self, ssf_bytes: bytes, memory: PatcherMemory, log) -> bytes:
+    def apply(self, ssf_bytes: bytes, memory: PatcherMemory, log: PatchLogger, game: Game) -> bytes:
         ssf: SSF = read_ssf(ssf_bytes)
         for modifier in self.modifiers:
             modifier.apply(ssf, memory)

--- a/pykotor/tslpatcher/mods/ssf.py
+++ b/pykotor/tslpatcher/mods/ssf.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pykotor.resource.formats.ssf.ssf_auto import bytes_ssf, read_ssf
+
 if TYPE_CHECKING:
     from pykotor.resource.formats.ssf import SSF, SSFSound
     from pykotor.tslpatcher.memory import PatcherMemory, TokenUsage
@@ -26,8 +28,11 @@ class ModificationsSSF:
         self.filename: str = filename
         self.destination = "Override"
         self.replace_file: bool = replace_file
+        self.no_replacefile_check = True
         self.modifiers: list[ModifySSF] = modifiers if modifiers is not None else []
 
-    def apply(self, ssf: SSF, memory: PatcherMemory) -> None:
+    def apply(self, ssf_bytes: bytes, memory: PatcherMemory, log) -> bytes:
+        ssf: SSF = read_ssf(ssf_bytes)
         for modifier in self.modifiers:
             modifier.apply(ssf, memory)
+        return bytes_ssf(ssf)

--- a/pykotor/tslpatcher/mods/ssf.py
+++ b/pykotor/tslpatcher/mods/ssf.py
@@ -24,6 +24,7 @@ class ModificationsSSF:
         modifiers: list[ModifySSF] | None = None,
     ):
         self.filename: str = filename
+        self.destination = "Override"
         self.replace_file: bool = replace_file
         self.modifiers: list[ModifySSF] = modifiers if modifiers is not None else []
 

--- a/pykotor/tslpatcher/mods/tlk.py
+++ b/pykotor/tslpatcher/mods/tlk.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pykotor.common.misc import ResRef
     from pykotor.resource.formats.tlk import TLK
+    from pykotor.tslpatcher.logger import PatchLogger
     from pykotor.tslpatcher.memory import PatcherMemory
 
 
@@ -14,12 +15,13 @@ class ModificationsTLK:
         self.filename = filename
         self.destination = destination
 
-    def apply(self, dialog: TLK, memory: PatcherMemory) -> None:
+    def apply(self, dialog: TLK, memory: PatcherMemory, log: PatchLogger) -> None:
         for modifier in self.modifiers:
             if modifier.is_replacement:
                 modifier.replace(dialog)
             else:
                 modifier.insert(dialog, memory)
+            log.complete_patch()
 
 
 class ModifyTLK:

--- a/pykotor/tslpatcher/mods/tlk.py
+++ b/pykotor/tslpatcher/mods/tlk.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pykotor.resource.formats.tlk.tlk_auto import bytes_tlk, read_tlk
+
 if TYPE_CHECKING:
-    from pykotor.common.misc import ResRef
+    from pykotor.common.misc import Game, ResRef
     from pykotor.resource.formats.tlk import TLK
     from pykotor.tslpatcher.logger import PatchLogger
     from pykotor.tslpatcher.memory import PatcherMemory
@@ -15,13 +17,15 @@ class ModificationsTLK:
         self.filename = filename
         self.destination = destination
 
-    def apply(self, dialog: TLK, memory: PatcherMemory, log: PatchLogger) -> None:
+    def apply(self, dialog_tlk_bytes: bytes, memory: PatcherMemory, log: PatchLogger, game: Game) -> bytes:
+        dialog = read_tlk(dialog_tlk_bytes)
         for modifier in self.modifiers:
             if modifier.is_replacement:
                 modifier.replace(dialog, memory)
             else:
                 modifier.insert(dialog, memory)
             log.complete_patch()
+        return bytes_tlk(dialog)
 
 
 class ModifyTLK:

--- a/pykotor/tslpatcher/mods/tlk.py
+++ b/pykotor/tslpatcher/mods/tlk.py
@@ -18,7 +18,7 @@ class ModificationsTLK:
     def apply(self, dialog: TLK, memory: PatcherMemory, log: PatchLogger) -> None:
         for modifier in self.modifiers:
             if modifier.is_replacement:
-                modifier.replace(dialog)
+                modifier.replace(dialog, memory)
             else:
                 modifier.insert(dialog, memory)
             log.complete_patch()
@@ -41,5 +41,6 @@ class ModifyTLK:
         dialog.add(self.text, self.sound.get())
         memory.memory_str[self.token_id] = len(dialog.entries) - 1
 
-    def replace(self, dialog: TLK) -> None:
+    def replace(self, dialog: TLK, memory: PatcherMemory) -> None:
         dialog.replace(self.token_id, self.text, self.sound.get())
+        memory.memory_str[self.token_id] = self.token_id

--- a/pykotor/tslpatcher/mods/tlk.py
+++ b/pykotor/tslpatcher/mods/tlk.py
@@ -9,8 +9,10 @@ if TYPE_CHECKING:
 
 
 class ModificationsTLK:
-    def __init__(self):
+    def __init__(self, filename="dialog.tlk", destination="."):
         self.modifiers: list[ModifyTLK] = []
+        self.filename = filename
+        self.destination = destination
 
     def apply(self, dialog: TLK, memory: PatcherMemory) -> None:
         for modifier in self.modifiers:

--- a/pykotor/tslpatcher/mods/twoda.py
+++ b/pykotor/tslpatcher/mods/twoda.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING, Any
 from pykotor.resource.formats.twoda.twoda_auto import bytes_2da, read_2da
 
 if TYPE_CHECKING:
+    from pykotor.common.misc import Game
     from pykotor.resource.formats.twoda import TwoDA, TwoDARow
+    from pykotor.tslpatcher.logger import PatchLogger
     from pykotor.tslpatcher.memory import PatcherMemory
 
 
@@ -58,7 +60,7 @@ class Modifications2DA:
         self.destination = "Override"
         self.modifiers: list[Modify2DA] = []
 
-    def apply(self, twoda_bytes: bytes, memory: PatcherMemory, log) -> bytes:
+    def apply(self, twoda_bytes: bytes, memory: PatcherMemory, log: PatchLogger, game: Game) -> bytes:
         twoda: TwoDA = read_2da(twoda_bytes)
         for row in self.modifiers:
             row.apply(twoda, memory)

--- a/pykotor/tslpatcher/mods/twoda.py
+++ b/pykotor/tslpatcher/mods/twoda.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any
 
+from pykotor.resource.formats.twoda.twoda_auto import bytes_2da, read_2da
+
 if TYPE_CHECKING:
     from pykotor.resource.formats.twoda import TwoDA, TwoDARow
     from pykotor.tslpatcher.memory import PatcherMemory
@@ -56,9 +58,11 @@ class Modifications2DA:
         self.destination = "Override"
         self.modifiers: list[Modify2DA] = []
 
-    def apply(self, twoda: TwoDA, memory: PatcherMemory) -> None:
+    def apply(self, twoda_bytes: bytes, memory: PatcherMemory, log) -> bytes:
+        twoda: TwoDA = read_2da(twoda_bytes)
         for row in self.modifiers:
             row.apply(twoda, memory)
+        return bytes_2da(twoda)
 
 
 # region Value Returners

--- a/pykotor/tslpatcher/mods/twoda.py
+++ b/pykotor/tslpatcher/mods/twoda.py
@@ -53,6 +53,7 @@ class Target:
 class Modifications2DA:
     def __init__(self, filename: str):
         self.filename: str = filename
+        self.destination = "Override"
         self.modifiers: list[Modify2DA] = []
 
     def apply(self, twoda: TwoDA, memory: PatcherMemory) -> None:

--- a/pykotor/tslpatcher/reader.py
+++ b/pykotor/tslpatcher/reader.py
@@ -447,7 +447,7 @@ class ConfigReader:
             for key, value in modifications_ini.items():
                 lowercase_key = key.lower()
                 if lowercase_key == "!destination":
-                    modifications.destination = CaseAwarePath(value)
+                    modifications.destination = value
                 elif lowercase_key == "!replacefile":
                     modifications.replace_file = bool(int(value))
                 elif lowercase_key in ["!filename", "!saveas"]:

--- a/scripts/holopatcher/__main__.py
+++ b/scripts/holopatcher/__main__.py
@@ -419,13 +419,22 @@ class App(tk.Tk):
         if directory.has_access(recurse):
             return True
         if (
-            messagebox.askyesno("Permission error", f"HoloPatcher does not have permissions to the path '{directory!s}', would you like to attempt to gain permission automatically?")
+            messagebox.askyesno(
+                "Permission error",
+                f"HoloPatcher does not have permissions to the path '{directory!s}', would you like to attempt to gain permission automatically?",
+            )
             and not directory.gain_access()
         ):
-            messagebox.showerror("Could not gain permission!", "Please run HoloPatcher with elevated permissions, and ensure the selected folder exists and is writeable.")
+            messagebox.showerror(
+                "Could not gain permission!",
+                "Please run HoloPatcher with elevated permissions, and ensure the selected folder exists and is writeable.",
+            )
             return False
         if not directory.has_access(recurse):
-            messagebox.showerror("Unauthorized", f"HoloPatcher needs permissions to access this folder '{directory!s}'. {os.linesep*2}Please fix this problem before attempting an installation. Ensure the folder is writeable or rerun holopatcher with elevated privileges.")
+            messagebox.showerror(
+                "Unauthorized",
+                f"HoloPatcher needs permissions to access this folder '{directory!s}'. {os.linesep*2}Please fix this problem before attempting an installation. Ensure the folder is writeable or rerun holopatcher with elevated privileges.",
+            )
             return False
         return True
 


### PR DESCRIPTION
The `ModInstaller.install()` is in serious need of a rewrite. This PR attempts to do that by extracting duplicate logic and moving the resource type-specific code into the apply functions.

TODO: Fix a problem where the wrong resource is selected (felix returns)
TODO: Don't ever load the `Installation` in patcher code as it shouldn't be needed